### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
     :target: https://travis-ci.org/inveniosoftware/xrootdpyfs
 .. image:: https://coveralls.io/repos/inveniosoftware/xrootdpyfs/badge.svg?branch=master
     :target: https://coveralls.io/r/inveniosoftware/xrootdpyfs
-.. image:: https://pypip.in/v/xrootdpyfs/badge.svg
+.. image:: https://img.shields.io/pypi/v/xrootdpyfs.svg
    :target: https://crate.io/packages/xrootdpyfs/
 
 XRootDPyFS is a PyFilesystem interface to XRootD.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20xrootdfs))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `xrootdfs`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.