### PR TITLE
xrdfile: fixed reading part of file bigger than 2GB when file cursor set over 2GB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ FROM centos:7
 RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 RUN yum group install -y "Development Tools"
-RUN yum install -y xrootd xrootd-server xrootd-client xrootd-client-devel xrootd-python git python-pip python-devel
-
+RUN yum-config-manager --add-repo http://xrootd.org/binaries/xrootd-stable-slc7.repo
+RUN yum --setopt=obsoletes=0  install -y xrootd-4.7.1 xrootd-client-4.7.1 xrootd-python-4.7.1 git  python-pip python-devel wget
 RUN adduser --uid 1001 xrootdpyfs
 
 # Install some prerequisites ahead of `setup.py` in order to profit

--- a/xrootdpyfs/__init__.py
+++ b/xrootdpyfs/__init__.py
@@ -181,7 +181,7 @@ from __future__ import absolute_import, print_function
 
 from .fs import XRootDPyFS
 from .opener import XRootDPyOpener
-from .xrdfile import XRootDPyFile
 from .version import __version__
+from .xrdfile import XRootDPyFile
 
 __all__ = ('__version__', 'XRootDPyFS', 'XRootDPyOpener', 'XRootDPyFile')

--- a/xrootdpyfs/xrdfile.py
+++ b/xrootdpyfs/xrdfile.py
@@ -185,7 +185,15 @@ class XRootDPyFile(object):
 
         self._assert_mode("r-")
 
-        chunksize = sizehint if sizehint > 0 else self.size
+        chunksize = sizehint if sizehint > 0 else self.size - self._ipp
+
+        if chunksize >= 2147483648:  # 2GB in bytes
+                raise IOError(
+                    "Chunksize is set to %s which is more than 2GB."
+                    "This is not supported!" % chunksize
+                )
+        elif chunksize < 0:
+            chunksize = 1
 
         # Read data
         statmsg, res = self._file.read(


### PR DESCRIPTION

Additionally dockerfile update for tests not to fail as last working xrootd is 4.7.1.

closes: #85