### PR TITLE
setup: fix xrootd incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     tests_require=tests_require,
     install_requires=[
         'fs>=0.4.0,<2.0',
-        'pyxrootd',
+        'xrootd',
     ],
     cmdclass={'test': PyTest},
     classifiers=[


### PR DESCRIPTION
* Latest xrootd v4.11.1 renamed the package from ``pyxrootd``
  to ``xrootd``.

Signed-off-by: Harris Tzovanakis <me@drjova.com>